### PR TITLE
Fill Command

### DIFF
--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -269,7 +269,10 @@ where
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let item = self.iterator.next()?;
+        let item = match self.iterator.next() {
+            Some(item) => item,
+            None => return None
+        };
         let result = match self.selection_index {
             ref mut sidx if (self.selection.get(*sidx) == Some(&self.index)) => {
                 *sidx += 1;

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -1,5 +1,6 @@
-use std::collections::hash_map::{HashMap, Entry};
+use std::collections::hash_map::{Entry, HashMap};
 use std::io;
+use std::iter;
 
 use csv;
 
@@ -35,8 +36,8 @@ Common options:
 
 type ByteString = Vec<u8>;
 
-type BoxedWriter = csv::Writer<Box<io::Write+'static>>;
-type BoxedReader = csv::Reader<Box<io::Read+'static>>;
+type BoxedWriter = csv::Writer<Box<io::Write + 'static>>;
+type BoxedReader = csv::Reader<Box<io::Read + 'static>>;
 
 #[derive(Deserialize)]
 struct Args {
@@ -45,7 +46,7 @@ struct Args {
     flag_output: Option<String>,
     flag_no_headers: bool,
     flag_delimiter: Option<Delimiter>,
-	flag_groupby: Option<SelectColumns>
+    flag_groupby: Option<SelectColumns>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -55,114 +56,177 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         .delimiter(args.flag_delimiter)
         .no_headers(args.flag_no_headers)
         .select(args.arg_selection);
-	
-	let wconfig = Config::new(&args.flag_output);
-	
-	let mut rdr = rconfig.reader()?;
-	let mut wtr = wconfig.writer()?;
-	
+
+    let wconfig = Config::new(&args.flag_output);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = wconfig.writer()?;
+
     let headers = rdr.byte_headers()?.clone();
     let select = rconfig.selection(&headers)?;
-	let groupby = match args.flag_groupby {
-		Some(value) => Some(value.selection(&headers, !rconfig.no_headers)?),
-		None => None,
-	};
-	
+    let groupby = match args.flag_groupby {
+        Some(value) => Some(value.selection(&headers, !rconfig.no_headers)?),
+        None => None,
+    };
+
     if !rconfig.no_headers {
         rconfig.write_headers(&mut rdr, &mut wtr)?;
     }
-	let ffill = ForwardFill::new(groupby, select);
-	ffill.fill(&mut rdr, &mut wtr)
+    let ffill = ForwardFill::new(groupby, select);
+    ffill.fill(&mut rdr, &mut wtr)
 }
 
 type Grouper = HashMap<Vec<ByteString>, HashMap<usize, ByteString>>;
 type VecRecord = Vec<ByteString>;
 
 trait Filler {
-	
-	fn groupbykey(&self, groupkey: Option<VecRecord>, record: &csv::ByteRecord, groupby: Option<&Selection>) -> Result<VecRecord, String> {
-		match groupkey {
-			Some(value) => Ok(value),
-			None => Ok(match groupby {
-				Some(ref value) => value.iter().map(|&i| record[i].to_vec()).collect(),
-				None => vec![]
-			})
-		}
-	}
-	
-	fn fill(self, rdr: &mut BoxedReader, wtr: &mut BoxedWriter) -> CliResult<()>;
-	fn memorize(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> CliResult<()>;
-	fn filledvalues(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> Result<VecRecord, String>;
+    fn groupbykey(
+        &self,
+        groupkey: Option<VecRecord>,
+        record: &csv::ByteRecord,
+        groupby: Option<&Selection>,
+    ) -> Result<VecRecord, String> {
+        match groupkey {
+            Some(value) => Ok(value),
+            None => Ok(match groupby {
+                Some(ref value) => value.iter().map(|&i| record[i].to_vec()).collect(),
+                None => vec![],
+            }),
+        }
+    }
+
+    fn fill(self, rdr: &mut BoxedReader, wtr: &mut BoxedWriter) -> CliResult<()>;
+    fn memorize(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> CliResult<()>;
+    fn filledvalues(
+        &mut self,
+        record: &csv::ByteRecord,
+        groupkey: Option<VecRecord>,
+    ) -> Result<VecRecord, String>;
 }
 
 struct ForwardFill {
-	grouper : Grouper,
-	groupby : Option<Selection>,
-	select : Selection,
+    grouper: Grouper,
+    groupby: Option<Selection>,
+    select: Selection,
 }
 
 impl ForwardFill {
-	
-	fn new(groupby: Option<Selection>, select: Selection) -> Self {
-		ForwardFill {
-			grouper: Grouper::new(),
-			groupby: groupby,
-			select: select
-		}
-	}
-	
+    fn new(groupby: Option<Selection>, select: Selection) -> Self {
+        ForwardFill {
+            grouper: Grouper::new(),
+            groupby: groupby,
+            select: select,
+        }
+    }
 }
 
 impl Filler for ForwardFill {
-	
-	fn fill(mut self, rdr: &mut BoxedReader, wtr: &mut BoxedWriter) -> CliResult<()> {
-		let mut record = csv::ByteRecord::new();
-	
-		while rdr.read_byte_record(&mut record)? {
-			
-			// Precompute groupby key
-			let groupbykey = Some(self.groupbykey(None, &record, self.groupby.as_ref())?);
-			self.memorize(&record, groupbykey.clone())?;
-			
-			let row = self.filledvalues(&record, groupbykey.clone())?;
-			wtr.write_record(row.iter())?;
-		}
-		wtr.flush()?;
-		Ok(())
-	}
-	
-	fn filledvalues(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> Result<VecRecord, String> {
-		let groupkey = self.groupbykey(groupkey, record, self.groupby.as_ref())?;
+    fn fill(mut self, rdr: &mut BoxedReader, wtr: &mut BoxedWriter) -> CliResult<()> {
+        let mut record = csv::ByteRecord::new();
 
-		let mut row : VecRecord = record.iter().map(|f| f.to_vec()).collect();
-		for &i in self.select.iter().filter(|&j| &record[*j] == b"") {
-			match self.grouper.get(&groupkey) {
-				None => {}
-				Some(v) => {
-					match v.get(&i) {
-						Some(f) => { row[i] = f.clone() },
-						None => {},
-					}
-				}
-			}
-		}
-		Ok(row)
-	}
-	
-	fn memorize(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> CliResult<()>	 {
-		let groupkey = self.groupbykey(groupkey, record, self.groupby.as_ref())?;
-		for &i in self.select.iter().filter(|&j| &record[*j] != b"") {
+        while rdr.read_byte_record(&mut record)? {
+            // Precompute groupby key
+            let groupbykey = Some(self.groupbykey(None, &record, self.groupby.as_ref())?);
+            self.memorize(&record, groupbykey.clone())?;
+
+            let row = self.filledvalues(&record, groupbykey.clone())?;
+            wtr.write_record(row.iter())?;
+        }
+        wtr.flush()?;
+        Ok(())
+    }
+
+    fn filledvalues(
+        &mut self,
+        record: &csv::ByteRecord,
+        groupkey: Option<VecRecord>,
+    ) -> Result<VecRecord, String> {
+        let groupkey = self.groupbykey(groupkey, record, self.groupby.as_ref())?;
+
+        let row: VecRecord = map_selected(
+            self.select.iter().map(|&x| x).collect(),
+            record.iter().map(|f| f.to_vec()).enumerate(),
+            |(i, field)| {
+                if field == b"" {
+                    match self.grouper.get(&groupkey) {
+                        None => (i, field),
+                        Some(v) => match v.get(&i) {
+                            Some(f) => (i, f.clone()),
+                            None => (i, field),
+                        },
+                    }
+                } else {
+                    (i, field)
+                }
+            },
+        ).map(|(_i, field)| field)
+            .collect();
+
+        Ok(row)
+    }
+
+    fn memorize(&mut self, record: &csv::ByteRecord, groupkey: Option<VecRecord>) -> CliResult<()> {
+        let groupkey = self.groupbykey(groupkey, record, self.groupby.as_ref())?;
+
+        for (i, field) in self.select
+            .iter()
+            .map(|&i| (i, &record[i]))
+            .filter(|&(i, field)| field != b"")
+        {
             match self.grouper.entry(groupkey.clone()) {
                 Entry::Vacant(v) => {
                     let mut values = HashMap::new();
-					values.insert(i, record[i].to_vec());
+                    values.insert(i, field.to_vec());
                     v.insert(values);
                 }
                 Entry::Occupied(mut v) => {
-                    v.get_mut().insert(i, record[i].to_vec());
+                    v.get_mut().insert(i, field.to_vec());
                 }
             }
-		}
-		Ok(())
-	}
+        }
+
+        Ok(())
+    }
+}
+
+struct MapSelected<I, F> {
+    selection: Vec<usize>,
+    selection_index: usize,
+    index: usize,
+    iterator: I,
+    predicate: F,
+}
+
+impl<I: iter::Iterator, F> iter::Iterator for MapSelected<I, F>
+where
+    F: FnMut(I::Item) -> I::Item,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.iterator.next()?;
+        let result = match self.selection_index {
+            ref mut sidx if (self.selection.get(*sidx) == Some(&self.index)) => {
+                *sidx += 1;
+                Some((self.predicate)(item))
+            }
+            _ => Some(item),
+        };
+        self.index += 1;
+        result
+    }
+}
+
+fn map_selected<B, I, F>(selection: Vec<usize>, iterator: I, predicate: F) -> MapSelected<I, F>
+where
+    F: FnMut(B) -> B,
+    I: iter::Iterator<Item = B>,
+{
+    MapSelected {
+        selection: selection,
+        selection_index: 0,
+        index: 0,
+        iterator: iterator,
+        predicate: predicate,
+    }
 }

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -11,15 +11,18 @@ use select::{SelectColumns, Selection};
 use util;
 
 static USAGE: &'static str = "
-Fill selected columns forwards in data.
+Fill empty fields in selected columns of a CSV.
 
 This command fills empty fields in the selected column
 using the last seen non-empty field in the CSV. This is
 useful to forward-fill values which may only be included
 the first time they are encountered.
 
-The option `--first` fills empty values using the first 
-seen non-empty value in that column, instead of the most 
+The option `--default <value>` fills all empty values
+in the selected columns with the provided default value.
+
+The option `--first` fills empty values using the first
+seen non-empty value in that column, instead of the most
 recent non-empty value in that column.
 
 The option `--backfill` fills empty values at the start of
@@ -46,6 +49,7 @@ fill options:
     -g --groupby <keys>    Group by specified columns.
     -f --first             Fill using the first valid value of a column, instead of the latest.
     -b --backfill          Fill initial empty values with the first valid value.
+    -v --default <value>   Fill using this default value.
 
 Common options:
     -h, --help             Display this message
@@ -71,7 +75,8 @@ struct Args {
     flag_delimiter: Option<Delimiter>,
     flag_groupby: Option<SelectColumns>,
     flag_first: bool,
-    flag_backfill: bool
+    flag_backfill: bool,
+    flag_default: Option<String>,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -100,26 +105,27 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let filler = Filler::new(groupby, select)
         .use_first_value(args.flag_first)
-        .backfill_empty_values(args.flag_backfill);
+        .backfill_empty_values(args.flag_backfill)
+        .use_default_value(args.flag_default);
     filler.fill(&mut rdr, &mut wtr)
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
-struct VecRecord(Vec<ByteString>);
+struct ByteRecord(Vec<ByteString>);
 
-impl VecRecord {
-    fn from_record(record: &csv::ByteRecord) -> Self {
-        VecRecord(record.iter().map(|f| f.to_vec()).collect())
+impl<'a> From<&'a csv::ByteRecord> for ByteRecord {
+    fn from(record: &'a csv::ByteRecord) -> Self {
+        ByteRecord(record.iter().map(|f| f.to_vec()).collect())
     }
 }
 
-impl iter::FromIterator<ByteString> for VecRecord {
+impl iter::FromIterator<ByteString> for ByteRecord {
     fn from_iter<T: IntoIterator<Item = ByteString>>(iter: T) -> Self {
-        VecRecord(Vec::from_iter(iter))
+        ByteRecord(Vec::from_iter(iter))
     }
 }
 
-impl iter::IntoIterator for VecRecord {
+impl iter::IntoIterator for ByteRecord {
     type Item = ByteString;
     type IntoIter = ::std::vec::IntoIter<ByteString>;
     fn into_iter(self) -> Self::IntoIter {
@@ -127,34 +133,48 @@ impl iter::IntoIterator for VecRecord {
     }
 }
 
-impl ops::Deref for VecRecord {
+impl ops::Deref for ByteRecord {
     type Target = [ByteString];
     fn deref(&self) -> &[ByteString] {
         &self.0
     }
 }
 
+type GroupKey = Option<ByteRecord>;
+type GroupBuffer = HashMap<GroupKey, Vec<ByteRecord>>;
+type Grouper = HashMap<GroupKey, GroupValues>;
+type GroupKeySelection = Option<Selection>;
 
-type GroupBuffer = HashMap<Option<VecRecord>, Vec<VecRecord>>;
-type GroupValues = HashMap<usize, ByteString>;
-type Grouper = HashMap<Option<VecRecord>, GroupValues>;
-type GroupKey = Option<Selection>;
-
-trait _GroupKey {
-    fn key(&self, record: &csv::ByteRecord) -> Result<Option<VecRecord>, String>;
+trait GroupKeyConstructor {
+    fn key(&self, record: &csv::ByteRecord) -> Result<GroupKey, String>;
 }
 
-impl _GroupKey for GroupKey {
-    fn key(&self, record: &csv::ByteRecord) -> Result<Option<VecRecord>, String> {
-         match *self {
-                Some(ref value) => Ok(Some(value.iter().map(|&i| record[i].to_vec()).collect())),
-                None => Ok(None),
+impl GroupKeyConstructor for GroupKeySelection {
+    fn key(&self, record: &csv::ByteRecord) -> Result<GroupKey, String> {
+        match *self {
+            Some(ref value) => Ok(Some(value.iter().map(|&i| record[i].to_vec()).collect())),
+            None => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GroupValues {
+    map: HashMap<usize, ByteString>,
+    default: Option<ByteString>,
+}
+
+impl GroupValues {
+    fn new(default: Option<ByteString>) -> Self {
+        Self {
+            map: HashMap::new(),
+            default: default,
         }
     }
 }
 
 trait GroupMemorizer {
-    fn fill(&self, selection: &Selection, record: VecRecord) ->  VecRecord;
+    fn fill(&self, selection: &Selection, record: ByteRecord) -> ByteRecord;
     fn memorize(&mut self, selection: &Selection, record: &csv::ByteRecord);
     fn memorize_first(&mut self, selection: &Selection, record: &csv::ByteRecord);
 }
@@ -162,34 +182,50 @@ trait GroupMemorizer {
 impl GroupMemorizer for GroupValues {
     fn memorize(&mut self, selection: &Selection, record: &csv::ByteRecord) {
         for &col in selection.iter().filter(|&col| !record[*col].is_empty()) {
-            self.insert(col, record[col].to_vec());
+            self.map.insert(col, record[col].to_vec());
         }
     }
 
     fn memorize_first(&mut self, selection: &Selection, record: &csv::ByteRecord) {
         for &col in selection.iter().filter(|&col| !record[*col].is_empty()) {
-            self.entry(col).or_insert(record[col].to_vec());
+            self.map.entry(col).or_insert(record[col].to_vec());
         }
     }
 
-    fn fill(&self, selection: &Selection, record: VecRecord) -> VecRecord {
-        record.into_iter().enumerate().map_selected(selection, |(col, field)|{
-            (col, if field.is_empty() { self.get(&col).unwrap_or(&field).to_vec() } else { field })
-        }).map(|(_, field)| field).collect()
+    fn fill(&self, selection: &Selection, record: ByteRecord) -> ByteRecord {
+        record
+            .into_iter()
+            .enumerate()
+            .map_selected(selection, |(col, field)| {
+                (
+                    col,
+                    if field.is_empty() {
+                        self.default
+                            .clone()
+                            .or_else(|| self.map.get(&col).cloned())
+                            .unwrap_or_else(|| field.to_vec())
+                    } else {
+                        field
+                    },
+                )
+            })
+            .map(|(_, field)| field)
+            .collect()
     }
 }
 
 struct Filler {
     grouper: Grouper,
-    groupby: GroupKey,
+    groupby: GroupKeySelection,
     select: Selection,
     buffer: GroupBuffer,
     first: bool,
-    backfill: bool
+    backfill: bool,
+    default_value: Option<ByteString>,
 }
 
 impl Filler {
-    fn new(groupby: GroupKey, select: Selection) -> Self {
+    fn new(groupby: GroupKeySelection, select: Selection) -> Self {
         Self {
             grouper: Grouper::new(),
             groupby: groupby,
@@ -197,6 +233,7 @@ impl Filler {
             buffer: GroupBuffer::new(),
             first: false,
             backfill: false,
+            default_value: None,
         }
     }
 
@@ -209,7 +246,12 @@ impl Filler {
         self.backfill = backfill;
         self
     }
-    
+
+    fn use_default_value(mut self, value: Option<String>) -> Self {
+        self.default_value = value.map(|v| v.as_bytes().to_vec());
+        self
+    }
+
     fn fill(mut self, rdr: &mut BoxedReader, wtr: &mut BoxedWriter) -> CliResult<()> {
         let mut record = csv::ByteRecord::new();
 
@@ -218,19 +260,25 @@ impl Filler {
             let key = self.groupby.key(&record)?;
 
             // Record valid fields, and fill empty fields
-            let group = self.grouper.entry(key.clone()).or_insert_with(HashMap::new);
+            let default_value = self.default_value.clone();
+            let group = self.grouper
+                .entry(key.clone())
+                .or_insert_with(|| GroupValues::new(default_value));
 
-            if self.first {
-                group.memorize_first(&self.select, &record);
-            } else {
-                group.memorize(&self.select, &record);
-            }
-            
-            let row = group.fill(&self.select, VecRecord::from_record(&record));
+            match (self.default_value.is_some(), self.first) {
+                (true, _) => {}
+                (false, true) => group.memorize_first(&self.select, &record),
+                (false, false) => group.memorize(&self.select, &record),
+            };
+
+            let row = group.fill(&self.select, ByteRecord::from(&record));
 
             // Handle buffering rows which still have nulls.
             if self.backfill && (self.select.iter().any(|&i| row[i] == b"")) {
-                self.buffer.entry(key.clone()).or_insert_with(Vec::new).push(row);
+                self.buffer
+                    .entry(key.clone())
+                    .or_insert_with(Vec::new)
+                    .push(row);
             } else {
                 if let Some(rows) = self.buffer.remove(&key) {
                     for buffered_row in rows {
@@ -286,17 +334,21 @@ where
 }
 
 trait Selectable<B>
-where Self : iter::Iterator<Item=B> + Sized
+where
+    Self: iter::Iterator<Item = B> + Sized,
 {
     fn map_selected<F>(self, selector: &Selection, predicate: F) -> MapSelected<Self, F>
-    where F: FnMut(B) -> B;
+    where
+        F: FnMut(B) -> B;
 }
 
 impl<B, C> Selectable<B> for C
-where C : iter::Iterator<Item=B> + Sized
+where
+    C: iter::Iterator<Item = B> + Sized,
 {
-    fn map_selected<F>(self, selector: &Selection, predicate: F) -> MapSelected<Self, F> 
-    where F: FnMut(B) -> B,
+    fn map_selected<F>(self, selector: &Selection, predicate: F) -> MapSelected<Self, F>
+    where
+        F: FnMut(B) -> B,
     {
         MapSelected {
             selection: selector.iter().map(|&x| x).collect(),

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -45,7 +45,7 @@ Usage:
 fill options:
     -g --groupby <keys>    Group by specified columns.
     -f --first             Fill using the first valid value of a column, instead of the latest.
-    -p --backfill          Fill initial empty values with the first valid value.
+    -b --backfill          Fill initial empty values with the first valid value.
 
 Common options:
     -h, --help             Display this message

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -17,13 +17,28 @@ using the last seen non-empty field in the CSV. This is
 useful to forward-fill values which may only be included
 the first time they are encountered.
 
+The option `--first` allows you to fill empty values
+using the first seen non-empty value in that column,
+even if the first valid value occurs after the first
+empty value. This requires buffering some rows in memory.
+
+The option `--groupby` groups the rows by the specified
+columns before filling in the empty values. Using this
+option, empty values are only filled with values which
+belong to the same group of rows, as determined by the
+columns selected in the `--groupby` option.
+
+When both `--groupby` and `--first` are specified, and the
+CSV is not sorted by the `--groupby` columns, rows may be
+re-ordered during output.
+
 Usage:
     xsv fill [options] [--] <selection> [<input>]
     xsv fill --help
 
 fill options:
-	-g --groupby <selection>     Group by specified columns.
-    -1 --first             Fill using the first value of a column.
+    -g --groupby <keys>    Group by specified columns.
+    -f --first             Fill using the first value of a column.
 
 Common options:
     -h, --help             Display this message

--- a/src/cmd/fill.rs
+++ b/src/cmd/fill.rs
@@ -1,0 +1,93 @@
+use csv;
+
+use CliResult;
+use config::{Config, Delimiter};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Fill selected columns forwards in data.
+
+This command fills empty fields in the selected column
+using the last seen non-empty field in the CSV. This is
+useful to forward-fill values which may only be included
+the first time they are encountered.
+
+Usage:
+    xsv fill [options] [--] <selection> [<input>]
+    xsv fill --help
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers. (i.e., They are not searched, analyzed,
+                           sliced, etc.)
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+type ByteString = Vec<u8>;
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    arg_selection: SelectColumns,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,	
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.arg_selection);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+
+    if !rconfig.no_headers {
+        rconfig.write_headers(&mut rdr, &mut wtr)?;
+    }
+	
+	let mut lastvalid : Vec<Option<ByteString>> = Vec::new();
+	{
+		let mut record = csv::ByteRecord::new();
+		rdr.read_byte_record(&mut record)?;
+		lastvalid.extend(record.iter().map(|v| match v {
+			b"" => None,
+			value @ _ => Some(value.to_vec())
+		}));
+		wtr.write_record(&record)?;
+	}
+	
+    for r in rdr.byte_records() {
+		let mut record = r?;
+		let mut riter = record.iter();
+		
+		for (i, field) in riter.enumerate() {
+			let mut field = field;		
+			
+			if sel.contains(&i) {
+				if field != b"" {
+					lastvalid[i] = Some(field.to_vec());
+				} else {
+					field = match lastvalid[i] {
+						None => b"",
+						Some(ref value) => value
+					}
+				}
+			}
+			wtr.write_field(field)?;
+		}
+		wtr.write_record(None::<&[u8]>)?;
+    }
+    wtr.flush()?;
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod cat;
 pub mod count;
+pub mod fill;
 pub mod fixlengths;
 pub mod flatten;
 pub mod fmt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ Please choose one of the following commands:",
 enum Command {
     Cat,
     Count,
+	Fill,
     FixLengths,
     Flatten,
     Fmt,
@@ -167,6 +168,7 @@ impl Command {
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
+			Command::Fill => cmd::fill::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ macro_rules! command_list {
 "
     cat         Concatenate by row or column
     count       Count records
+    fill        Fill empty values
     fixlengths  Makes all records have same length
     flatten     Show one field per line
     fmt         Format CSV output (change field delimiter)

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ Please choose one of the following commands:",
 enum Command {
     Cat,
     Count,
-	Fill,
+    Fill,
     FixLengths,
     Flatten,
     Fmt,
@@ -169,7 +169,7 @@ impl Command {
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
-			Command::Fill => cmd::fill::run(argv),
+            Command::Fill => cmd::fill::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -12,23 +12,24 @@ fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_he
 }
 
 #[test]
-fn fill_forward_one() {
+fn fill_forward() {
     let rows = vec![
         svec!["h1", "h2", "h3"],
+        svec!["", "b", "c"],
         svec!["a", "b", "c"],
         svec!["", "d", "e"],
         svec!["f", "g", "h"],
         svec!["", "i", "j"],
     ];
 
-    let wrk = Workdir::new("fill_forward_one").flexible(true);
+    let wrk = Workdir::new("fill_forward").flexible(true);
     wrk.create("in.csv", rows);
 
     let mut cmd = wrk.command("fill");
     cmd.arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["a", "a", "f", "f"];
+    let expected = svec!["", "a", "a", "f", "f"];
     compare_column(&got, &expected, 0, true);
 }
 
@@ -36,6 +37,7 @@ fn fill_forward_one() {
 fn fill_forward_groupby() {
     let rows = vec![
         svec!["h1", "h2", "h3"],
+        svec!["", "b", "e"],
         svec!["a", "b", "c"],
         svec!["", "b", "e"],
         svec!["f", "c", "h"],
@@ -51,6 +53,56 @@ fn fill_forward_groupby() {
     cmd.args(&vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["a", "a", "f", "f", "a", "f"];
+    let expected = svec!["", "a", "a", "f", "f", "a", "f"];
+    compare_column(&got, &expected, 0, true);
+}
+
+#[test]
+fn fill_first_groupby() {
+    let rows = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["", "b", "e"],
+        svec!["", "c", "j"],
+        svec!["a", "b", "c"],
+        svec!["", "b", "e"],
+        svec!["f", "c", "h"],
+        svec!["", "c", "j"],
+        svec!["", "b", "j"],
+        svec!["", "c", "j"],
+    ];
+
+    let wrk = Workdir::new("fill_first_groupby").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("fill");
+    cmd.args(&vec!["-g", "2"]).arg("--first").arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["a", "a", "a", "f", "f", "f", "a", "f"];
+    compare_column(&got, &expected, 0, true);
+}
+
+#[test]
+fn fill_first() {
+    let rows = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["", "b", "e"],
+        svec!["", "c", "j"],
+        svec!["a", "b", "c"],
+        svec!["", "b", "e"],
+        svec!["f", "c", "h"],
+        svec!["", "c", "j"],
+        svec!["", "b", "j"],
+        svec!["", "c", "j"],
+    ];
+
+    let wrk = Workdir::new("fill_first").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--first").arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["a", "a", "a", "a", "f", "a", "a", "a"];
     compare_column(&got, &expected, 0, true);
 }

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -11,100 +11,126 @@ fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_he
     }
 }
 
+fn example() -> Vec<Vec<String>> {
+     vec![
+        svec!["h1", "h2", "h3"],
+        svec!["", "baz", "egg"],
+        svec!["", "foo", ""],
+        svec!["abc", "baz", "foo"],
+        svec!["", "baz", "egg"],
+        svec!["zap", "baz", "foo"],
+        svec!["bar", "foo", ""],
+        svec!["bongo", "foo", ""],
+        svec!["", "foo", "jar"],
+        svec!["", "baz", "jar"],
+        svec!["", "foo", "jar"],
+    ]
+}
+
 #[test]
 fn fill_forward() {
-    let rows = vec![
-        svec!["h1", "h2", "h3"],
-        svec!["", "b", "c"],
-        svec!["a", "b", "c"],
-        svec!["", "d", ""],
-        svec!["f", "g", "h"],
-        svec!["", "i", "j"],
-    ];
 
-    let wrk = Workdir::new("fill_forward").flexible(true);
-    wrk.create("in.csv", rows);
+    let wrk = Workdir::new("fill_forward");
+    wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
     cmd.arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["", "a", "a", "f", "f"];
+    
+    // Filled target column
+    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
     compare_column(&got, &expected, 0, true);
-    let expected = svec!["c", "c", "", "h", "j"];
+
+    // Left non-target column alone
+    let expected = svec!["egg", "", "foo", "egg", "foo", "", "", "jar", "jar", "jar"];
+    compare_column(&got, &expected, 2, true);
+}
+
+#[test]
+fn fill_forward_both() {
+
+    let wrk = Workdir::new("fill_forward");
+    wrk.create("in.csv", example());
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--").arg("1,3").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    
+    // Filled target column
+    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
+    compare_column(&got, &expected, 0, true);
+
+    let expected = svec!["egg", "egg", "foo", "egg", "foo", "foo", "foo", "jar", "jar", "jar"];
     compare_column(&got, &expected, 2, true);
 }
 
 #[test]
 fn fill_forward_groupby() {
-    let rows = vec![
-        svec!["h1", "h2", "h3"],
-        svec!["", "b", "e"],
-        svec!["a", "b", "c"],
-        svec!["", "b", "e"],
-        svec!["f", "c", "h"],
-        svec!["", "c", "j"],
-        svec!["", "b", "j"],
-        svec!["", "c", "j"],
-    ];
 
     let wrk = Workdir::new("fill_forward_groupby").flexible(true);
-    wrk.create("in.csv", rows);
+    wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
     cmd.args(&vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["", "a", "a", "f", "f", "a", "f"];
+    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "zap", "bongo"];
     compare_column(&got, &expected, 0, true);
 }
 
 #[test]
 fn fill_first_groupby() {
-    let rows = vec![
-        svec!["h1", "h2", "h3"],
-        svec!["", "b", "e"],
-        svec!["", "c", "j"],
-        svec!["a", "b", "c"],
-        svec!["", "b", "e"],
-        svec!["f", "c", "h"],
-        svec!["", "c", "j"],
-        svec!["", "b", "j"],
-        svec!["", "c", "j"],
-    ];
 
     let wrk = Workdir::new("fill_first_groupby").flexible(true);
-    wrk.create("in.csv", rows);
+    wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
     cmd.args(&vec!["-g", "2"]).arg("--first").arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["a", "a", "a", "f", "f", "f", "a", "f"];
+    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bar", "abc", "bar"];
     compare_column(&got, &expected, 0, true);
 }
 
 #[test]
 fn fill_first() {
-    let rows = vec![
-        svec!["h1", "h2", "h3"],
-        svec!["", "b", "e"],
-        svec!["", "c", "j"],
-        svec!["a", "b", "c"],
-        svec!["", "b", "e"],
-        svec!["f", "c", "h"],
-        svec!["", "c", "j"],
-        svec!["", "b", "j"],
-        svec!["", "c", "j"],
-    ];
+
 
     let wrk = Workdir::new("fill_first").flexible(true);
-    wrk.create("in.csv", rows);
+    wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
     cmd.arg("--first").arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["a", "a", "a", "a", "f", "a", "a", "a"];
+    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"];
+    compare_column(&got, &expected, 0, true);
+}
+
+#[test]
+fn fill_backfill() {
+    let wrk = Workdir::new("fill_backfill").flexible(true);
+    wrk.create("in.csv", example());
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--backfill").arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["abc", "abc", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
+    compare_column(&got, &expected, 0, true);
+}
+
+#[test]
+fn fill_backfill_first() {
+    let wrk = Workdir::new("fill_backfill").flexible(true);
+    wrk.create("in.csv", example());
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--backfill").arg("--first").arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["abc", "abc", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"];
     compare_column(&got, &expected, 0, true);
 }

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -1,6 +1,14 @@
 use CsvRecord;
 use workdir::Workdir;
 
+fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_header: bool) {
+
+
+    for (value, value_expected) in got.iter().skip(if skip_header {1} else {0}).map(|row| &row[column]).zip(expected.iter()) {
+		assert_eq!(value, value_expected)
+	}
+}
+
 #[test]
 fn fill_forward_one() {
     let rows = vec![
@@ -18,10 +26,8 @@ fn fill_forward_one() {
     cmd.arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    assert_eq!(got[1][0], "a");
-    assert_eq!(got[2][0], "a");
-    assert_eq!(got[3][0], "f");
-    assert_eq!(got[4][0], "f");
+    let expected = svec!["a", "a", "f", "f"];
+    compare_column(&got, &expected, 0, true);
 }
 
 #[test]
@@ -45,8 +51,6 @@ fn fill_forward_groupby() {
 	
 	let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
 	let expected = svec!["a", "a", "f", "f", "a", "f"];
-	for (v, v_expected) in got.iter().skip(1).map(|row| &row[0]).zip(expected.iter()) {
-		assert_eq!(v, v_expected)
-	}
+    compare_column(&got, &expected, 0, true);
 	
 }

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -1,0 +1,27 @@
+use quickcheck::TestResult;
+
+use {CsvRecord, qcheck};
+use workdir::Workdir;
+
+#[test]
+fn fill_forward_one() {
+    let rows = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["a", "b", "c"],
+        svec!["", "d", "e"],
+        svec!["f", "g", "h"],
+        svec!["", "i", "j"],
+    ];
+
+    let wrk = Workdir::new("fixlengths_all_maxlen_trims").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    assert_eq!(got[1][0], "a");
+    assert_eq!(got[2][0], "a");
+    assert_eq!(got[3][0], "f");
+    assert_eq!(got[4][0], "f");
+}

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -12,7 +12,7 @@ fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_he
 }
 
 fn example() -> Vec<Vec<String>> {
-     vec![
+    vec![
         svec!["h1", "h2", "h3"],
         svec!["", "baz", "egg"],
         svec!["", "foo", ""],
@@ -29,7 +29,6 @@ fn example() -> Vec<Vec<String>> {
 
 #[test]
 fn fill_forward() {
-
     let wrk = Workdir::new("fill_forward");
     wrk.create("in.csv", example());
 
@@ -37,9 +36,11 @@ fn fill_forward() {
     cmd.arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    
+
     // Filled target column
-    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
+    let expected = svec![
+        "", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"
+    ];
     compare_column(&got, &expected, 0, true);
 
     // Left non-target column alone
@@ -49,7 +50,6 @@ fn fill_forward() {
 
 #[test]
 fn fill_forward_both() {
-
     let wrk = Workdir::new("fill_forward");
     wrk.create("in.csv", example());
 
@@ -57,18 +57,21 @@ fn fill_forward_both() {
     cmd.arg("--").arg("1,3").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    
+
     // Filled target column
-    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
+    let expected = svec![
+        "", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"
+    ];
     compare_column(&got, &expected, 0, true);
 
-    let expected = svec!["egg", "egg", "foo", "egg", "foo", "foo", "foo", "jar", "jar", "jar"];
+    let expected = svec![
+        "egg", "egg", "foo", "egg", "foo", "foo", "foo", "jar", "jar", "jar"
+    ];
     compare_column(&got, &expected, 2, true);
 }
 
 #[test]
 fn fill_forward_groupby() {
-
     let wrk = Workdir::new("fill_forward_groupby").flexible(true);
     wrk.create("in.csv", example());
 
@@ -76,28 +79,33 @@ fn fill_forward_groupby() {
     cmd.args(&vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "zap", "bongo"];
+    let expected = svec![
+        "", "", "abc", "abc", "zap", "bar", "bongo", "bongo", "zap", "bongo"
+    ];
     compare_column(&got, &expected, 0, true);
 }
 
 #[test]
 fn fill_first_groupby() {
-
     let wrk = Workdir::new("fill_first_groupby").flexible(true);
     wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
-    cmd.args(&vec!["-g", "2"]).arg("--first").arg("--").arg("1").arg("in.csv");
+    cmd.args(&vec!["-g", "2"])
+        .arg("--first")
+        .arg("--")
+        .arg("1")
+        .arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "bar", "abc", "bar"];
+    let expected = svec![
+        "", "", "abc", "abc", "zap", "bar", "bongo", "bar", "abc", "bar"
+    ];
     compare_column(&got, &expected, 0, true);
 }
 
 #[test]
 fn fill_first() {
-
-
     let wrk = Workdir::new("fill_first").flexible(true);
     wrk.create("in.csv", example());
 
@@ -105,7 +113,9 @@ fn fill_first() {
     cmd.arg("--first").arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["", "", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"];
+    let expected = svec![
+        "", "", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"
+    ];
     compare_column(&got, &expected, 0, true);
 }
 
@@ -118,7 +128,9 @@ fn fill_backfill() {
     cmd.arg("--backfill").arg("--").arg("1").arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["abc", "abc", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"];
+    let expected = svec![
+        "abc", "abc", "abc", "abc", "zap", "bar", "bongo", "bongo", "bongo", "bongo"
+    ];
     compare_column(&got, &expected, 0, true);
 }
 
@@ -128,9 +140,34 @@ fn fill_backfill_first() {
     wrk.create("in.csv", example());
 
     let mut cmd = wrk.command("fill");
-    cmd.arg("--backfill").arg("--first").arg("--").arg("1").arg("in.csv");
+    cmd.arg("--backfill")
+        .arg("--first")
+        .arg("--")
+        .arg("1")
+        .arg("in.csv");
 
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-    let expected = svec!["abc", "abc", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"];
+    let expected = svec![
+        "abc", "abc", "abc", "abc", "zap", "bar", "bongo", "abc", "abc", "abc"
+    ];
+    compare_column(&got, &expected, 0, true);
+}
+
+#[test]
+fn fill_default() {
+    let wrk = Workdir::new("fill_default").flexible(true);
+    wrk.create("in.csv", example());
+
+    let mut cmd = wrk.command("fill");
+    cmd.arg("--default")
+        .arg("dat")
+        .arg("--")
+        .arg("1")
+        .arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec![
+        "dat", "dat", "abc", "dat", "zap", "bar", "bongo", "dat", "dat", "dat"
+    ];
     compare_column(&got, &expected, 0, true);
 }

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -2,11 +2,13 @@ use CsvRecord;
 use workdir::Workdir;
 
 fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_header: bool) {
-
-
-    for (value, value_expected) in got.iter().skip(if skip_header {1} else {0}).map(|row| &row[column]).zip(expected.iter()) {
-		assert_eq!(value, value_expected)
-	}
+    for (value, value_expected) in got.iter()
+        .skip(if skip_header { 1 } else { 0 })
+        .map(|row| &row[column])
+        .zip(expected.iter())
+    {
+        assert_eq!(value, value_expected)
+    }
 }
 
 #[test]
@@ -32,7 +34,6 @@ fn fill_forward_one() {
 
 #[test]
 fn fill_forward_groupby() {
-	
     let rows = vec![
         svec!["h1", "h2", "h3"],
         svec!["a", "b", "c"],
@@ -42,15 +43,14 @@ fn fill_forward_groupby() {
         svec!["", "b", "j"],
         svec!["", "c", "j"],
     ];
-	
+
     let wrk = Workdir::new("fill_forward_groupby").flexible(true);
     wrk.create("in.csv", rows);
 
     let mut cmd = wrk.command("fill");
-    cmd.args(&vec!["-g","2"]).arg("--").arg("1").arg("in.csv");
-	
-	let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
-	let expected = svec!["a", "a", "f", "f", "a", "f"];
+    cmd.args(&vec!["-g", "2"]).arg("--").arg("1").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["a", "a", "f", "f", "a", "f"];
     compare_column(&got, &expected, 0, true);
-	
 }

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -17,7 +17,7 @@ fn fill_forward() {
         svec!["h1", "h2", "h3"],
         svec!["", "b", "c"],
         svec!["a", "b", "c"],
-        svec!["", "d", "e"],
+        svec!["", "d", ""],
         svec!["f", "g", "h"],
         svec!["", "i", "j"],
     ];
@@ -31,6 +31,8 @@ fn fill_forward() {
     let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
     let expected = svec!["", "a", "a", "f", "f"];
     compare_column(&got, &expected, 0, true);
+    let expected = svec!["c", "c", "", "h", "j"];
+    compare_column(&got, &expected, 2, true);
 }
 
 #[test]

--- a/tests/test_fill.rs
+++ b/tests/test_fill.rs
@@ -1,6 +1,4 @@
-use quickcheck::TestResult;
-
-use {CsvRecord, qcheck};
+use CsvRecord;
 use workdir::Workdir;
 
 #[test]
@@ -13,7 +11,7 @@ fn fill_forward_one() {
         svec!["", "i", "j"],
     ];
 
-    let wrk = Workdir::new("fixlengths_all_maxlen_trims").flexible(true);
+    let wrk = Workdir::new("fill_forward_one").flexible(true);
     wrk.create("in.csv", rows);
 
     let mut cmd = wrk.command("fill");
@@ -24,4 +22,31 @@ fn fill_forward_one() {
     assert_eq!(got[2][0], "a");
     assert_eq!(got[3][0], "f");
     assert_eq!(got[4][0], "f");
+}
+
+#[test]
+fn fill_forward_groupby() {
+	
+    let rows = vec![
+        svec!["h1", "h2", "h3"],
+        svec!["a", "b", "c"],
+        svec!["", "b", "e"],
+        svec!["f", "c", "h"],
+        svec!["", "c", "j"],
+        svec!["", "b", "j"],
+        svec!["", "c", "j"],
+    ];
+	
+    let wrk = Workdir::new("fill_forward_groupby").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("fill");
+    cmd.args(&vec!["-g","2"]).arg("--").arg("1").arg("in.csv");
+	
+	let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+	let expected = svec!["a", "a", "f", "f", "a", "f"];
+	for (v, v_expected) in got.iter().skip(1).map(|row| &row[0]).zip(expected.iter()) {
+		assert_eq!(v, v_expected)
+	}
+	
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ mod workdir;
 
 mod test_cat;
 mod test_count;
+mod test_fill;
 mod test_fixlengths;
 mod test_flatten;
 mod test_fmt;


### PR DESCRIPTION
An `xsv` command to fill in null values, with support for groupby, fill forward, and fill first found value.

Works like:
```
xsv fill -g 1,2 -f 3- data.csv > result.csv
```
which would group by the first and second columns, and fill the 3-inf columns based on the first non-empty value (both backwards and forwards) in each column.

Simply doing
```
xsv fill 3- data.csv > result.csv
```
will fill the 3rd through last column using the most recent non-empty value.