### PR TITLE
Coalesce Command

### DIFF
--- a/src/cmd/coalesce.rs
+++ b/src/cmd/coalesce.rs
@@ -1,0 +1,74 @@
+use std::iter::once;
+
+use csv;
+
+use CliResult;
+use config::{Config, Delimiter};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Coalsece multiple columns, selecting the first non-empty column.
+
+Usage:
+    xsv coalesce [options] [--] <selection> [<input>]
+    xsv coalesce --help
+
+coalesce options:
+    --name <name>       Name the coalesced column, otherwise infers the
+                           the name as the first header value.
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers. (i.e., They are not searched, analyzed,
+                           sliced, etc.)
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    arg_selection: SelectColumns,
+	flag_name: Option<String>,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+macro_rules! coalesce {
+    ($record:expr, $select:expr) => {
+        $record.iter().chain($select.iter().map(|&i| &$record[i]).filter(|&f| f != b"").chain(once(&b""[..])).take(1))
+    };
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.arg_selection);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+
+    if !rconfig.no_headers {
+        match args.flag_name {
+            None => wtr.write_record(coalesce!(&headers, &sel))?,
+            Some(name) => wtr.write_record(headers.iter().chain(once(name.as_bytes())))?,
+        };
+    }
+	
+    let mut record = csv::ByteRecord::new();
+    while rdr.read_byte_record(&mut record)? {
+        wtr.write_record(coalesce!(&record, &sel))?;
+    }
+    wtr.flush()?;
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod cat;
+pub mod coalesce;
 pub mod count;
 pub mod fixlengths;
 pub mod flatten;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ macro_rules! command_list {
     () => (
 "
     cat         Concatenate by row or column
+    coalesce    Coalesce empty-valued columns
     count       Count records
     fixlengths  Makes all records have same length
     flatten     Show one field per line
@@ -138,6 +139,7 @@ Please choose one of the following commands:",
 #[derive(Debug, Deserialize)]
 enum Command {
     Cat,
+    Coalesce,
     Count,
     FixLengths,
     Flatten,
@@ -167,6 +169,7 @@ impl Command {
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
+            Command::Coalesce => cmd::coalesce::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,8 +168,8 @@ impl Command {
         let argv = &*argv;
         match self {
             Command::Cat => cmd::cat::run(argv),
-            Command::Count => cmd::count::run(argv),
             Command::Coalesce => cmd::coalesce::run(argv),
+            Command::Count => cmd::count::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/tests/test_coalesce.rs
+++ b/tests/test_coalesce.rs
@@ -1,0 +1,55 @@
+use CsvRecord;
+use workdir::Workdir;
+
+fn compare_column(got: &[CsvRecord], expected: &[String], column: usize, skip_header: bool) {
+    for (value, value_expected) in got.iter()
+        .skip(if skip_header { 1 } else { 0 })
+        .map(|row| &row[column])
+        .zip(expected.iter())
+    {
+        assert_eq!(value, value_expected)
+    }
+}
+
+fn simple_rows() -> Vec<Vec<String>> {
+    vec![
+        svec!["h1", "h2", "h3"],
+        svec!["", "b", "c"],
+        svec!["a", "b", "c"],
+        svec!["", "d", ""],
+        svec!["f", "g", ""],
+        svec!["", "i", "j"],
+    ]
+}
+
+#[test]
+fn coalesce() {
+    let rows = simple_rows();
+    
+    let wrk = Workdir::new("coalesce").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("coalesce");
+    cmd.arg("--").arg("1,3").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["c", "a", "", "f", "j"];
+    compare_column(&got, &expected, 3, true);
+}
+
+#[test]
+fn coalesce_with_name() {
+    let rows = simple_rows();
+
+    let wrk = Workdir::new("coalesce_with_name").flexible(true);
+    wrk.create("in.csv", rows);
+
+    let mut cmd = wrk.command("coalesce");
+    cmd.args(vec!["--name", "h4"]).arg("--").arg("1,3").arg("in.csv");
+
+    let got: Vec<CsvRecord> = wrk.read_stdout(&mut cmd);
+    let expected = svec!["c", "a", "", "f", "j"];
+    compare_column(&got, &expected, 3, true);
+
+    assert_eq!(got[0][3], "h4");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -34,6 +34,7 @@ macro_rules! rassert_eq {
 mod workdir;
 
 mod test_cat;
+mod test_coalesce;
 mod test_count;
 mod test_fixlengths;
 mod test_flatten;


### PR DESCRIPTION
Coalesce multiple (possibly empty) columns into a single new column (at the end of the CSV) which will contain the value from the first non-empty column.

```
xsv coalesce -- 1,5,4 data.csv
```
Coalesces values in the 1st, 5th, and 4th column, selecting the first non-empty value from those columns in that order. The output column name will be set by the same logic.